### PR TITLE
Fix issue#72

### DIFF
--- a/jsonmodels/parsers.py
+++ b/jsonmodels/parsers.py
@@ -24,10 +24,12 @@ def to_struct(model):
         if value is None:
             continue
 
-        if isinstance(value, list):
+        if isinstance(field, fields.ListField):
             resp[name] = [to_struct(item) for item in value]
-        else:
+        elif isinstance(field, fields.EmbeddedField):
             resp[name] = to_struct(value)
+        else:
+            resp[name] = field.to_struct(value)
     return resp
 
 

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -185,3 +185,45 @@ def test_list_to_struct():
         ]
     }
     assert pattern == person.to_struct()
+
+
+def test_to_struct_time():
+
+    class Clock(models.Base):
+        time = fields.TimeField()
+
+    clock = Clock()
+    clock.time = '12:03:34'
+
+    pattern = {
+        'time': '12:03:34'
+    }
+    assert pattern == clock.to_struct()
+
+
+def test_to_struct_date():
+
+    class Event(models.Base):
+        start = fields.DateField()
+
+    event = Event()
+    event.start = '2014-04-21'
+
+    pattern = {
+        'start': '2014-04-21'
+    }
+    assert pattern == event.to_struct()
+
+
+def test_to_struct_datetime():
+
+    class Event(models.Base):
+        start = fields.DateTimeField()
+
+    event = Event()
+    event.start = '2013-05-06 12:03:34'
+
+    pattern = {
+        'start': '2013-05-06T12:03:34'
+    }
+    assert pattern == event.to_struct()


### PR DESCRIPTION
(For a more detailed description of the underlying problem see issue #72.)

In order to properly [cast jsonmodels' objects into python structs and, furthermore, valid json strings](https://jsonmodels.readthedocs.io/en/latest/usage.html#casting-to-python-struct-and-json), `to_struct` in `parser.py` has been modified. It now distinguishes between a `ListField`, an `EmbeddedField` and basic field types.

Furthermore, additional tests have been added to `test_struct.py`. Please note, that none of these tests will pass without the modifications done in `parser.py`.