### PR TITLE
Add __eq__ to models that compare based on fields

### DIFF
--- a/jsonmodels/fields.py
+++ b/jsonmodels/fields.py
@@ -33,7 +33,7 @@ class BaseField(object):
         self._finish_initialization(type(instance))
         value = self.parse_value(value)
         self.validate(value)
-        self.memory[instance] = value
+        self.memory[instance._cache_key] = value
 
     def __get__(self, instance, owner=None):
         if instance is None:
@@ -43,13 +43,13 @@ class BaseField(object):
         self._finish_initialization(type(instance))
 
         self._check_value(instance)
-        return self.memory[instance]
+        return self.memory[instance._cache_key]
 
     def _finish_initialization(self, owner):
         pass
 
     def _check_value(self, obj):
-        if obj not in self.memory:
+        if obj._cache_key not in self.memory:
             self.__set__(obj, self.get_default_value())
 
     def validate_for_object(self, obj):

--- a/jsonmodels/models.py
+++ b/jsonmodels/models.py
@@ -5,11 +5,16 @@ from .fields import BaseField
 from .errors import ValidationError
 
 
+class _CacheKey(object):
+    pass
+
+
 class Base(object):
 
     """Base class for all models."""
 
     def __init__(self, **kwargs):
+        self._cache_key = _CacheKey()
         self.populate(**kwargs)
 
     def populate(self, **kw):
@@ -80,3 +85,19 @@ class Base(object):
                 "Error for field '{name}'.".format(name=name),
                 error
             )
+
+    def __eq__(self, other):
+        if type(other) is not type(self):
+            return False
+
+        for name, _ in self.iterate_over_fields():
+            our = getattr(self, name)
+            their = getattr(other, name)
+
+            if our != their:
+                return False
+
+        return True
+
+    def __ne__(self, other):
+        return not (self == other)

--- a/tests/test_jsonmodels.py
+++ b/tests/test_jsonmodels.py
@@ -469,3 +469,98 @@ def test_assignation_of_list_of_models():
     viper = Car()
     viper.wheels = None
     viper.wheels = [Wheel()]
+
+
+def test_equality_of_different_types():
+    class A(models.Base):
+        pass
+
+    class B(A):
+        pass
+
+    class C(models.Base):
+        pass
+
+    assert A() == A()
+    assert A() != B()
+    assert B() != A()
+    assert A() != C()
+
+
+def test_equality_of_simple_models():
+    class Person(models.Base):
+        name = fields.StringField()
+        age = fields.IntField()
+
+    p1 = Person(name='Jack')
+    p2 = Person(name='Jack')
+
+    assert p1 == p2
+    assert p2 == p1
+
+    p3 = Person(name='Jack', age=100)
+    assert p1 != p3
+    assert p3 != p1
+
+    p4 = Person(name='Jill')
+    assert p1 != p4
+    assert p4 != p1
+
+
+def test_equality_embedded_objects():
+    class Person(models.Base):
+        name = fields.StringField()
+
+    class Company(models.Base):
+        chairman = fields.EmbeddedField(Person)
+
+    c1 = Company(chairman=Person(name='Pete'))
+    c2 = Company(chairman=Person(name='Pete'))
+
+    assert c1 == c2
+    assert c2 == c1
+
+    c3 = Company(chairman=Person(name='Joshua'))
+
+    assert c1 != c3
+    assert c3 != c1
+
+
+def test_equality_list_fields():
+
+    class Wheel(models.Base):
+        pressure = fields.FloatField()
+
+    class Car(models.Base):
+
+        wheels = fields.ListField(items_types=[Wheel])
+
+    car = Car(
+        wheels=[
+            Wheel(pressure=1),
+            Wheel(pressure=2),
+            Wheel(pressure=3),
+            Wheel(pressure=4),
+        ],
+    )
+
+    another_car = Car(
+        wheels=[
+            Wheel(pressure=1),
+            Wheel(pressure=2),
+            Wheel(pressure=3),
+            Wheel(pressure=4),
+        ],
+    )
+
+    assert car == another_car
+
+    different_car = Car(
+        wheels=[
+            Wheel(pressure=4),
+            Wheel(pressure=3),
+            Wheel(pressure=2),
+            Wheel(pressure=1),
+        ],
+    )
+    assert car != different_car


### PR DESCRIPTION
This patch adds the ability to compare model instances based on their
type and fields (rather than their reference).

This patch also adds `_cache_key` member and changes `Field.memory` access
to be by `obj._cache_key` rather than `obj` itself. This had to be done
because memory's `__getitem__` called obj's `__eq__` and caused stack
overflow.