### PR TITLE
Added object title in JSON schema

### DIFF
--- a/jsonmodels/builders.py
+++ b/jsonmodels/builders.py
@@ -90,6 +90,7 @@ class ObjectBuilder(Builder):
         )
         schema = {
             'type': 'object',
+            'title': self.type.__name__,
             'additionalProperties': False,
             'properties': properties,
         }


### PR DESCRIPTION
Added class name as object title in json schema. Really useful when creating forms from schema (especially in lists). 