### PR TITLE
Handle None values in parse_value for Time and Date Fields

### DIFF
--- a/jsonmodels/fields.py
+++ b/jsonmodels/fields.py
@@ -377,6 +377,8 @@ class TimeField(StringField):
 
     def parse_value(self, value):
         """Parse string into instance of `time`."""
+        if value is None:
+            return value
         if isinstance(value, datetime.time):
             return value
         return parse(value).timetz()
@@ -407,6 +409,8 @@ class DateField(StringField):
 
     def parse_value(self, value):
         """Parse string into instance of `date`."""
+        if value is None:
+            return value
         if isinstance(value, datetime.date):
             return value
         return parse(value).date()


### PR DESCRIPTION
Have parse_value return None when the passed value is None. This allows
DateField and TimeField to return None rather than fail with a TypeError
when the original value is None (or non-existant). This can happen when
e.g. serializing an object where the Date (or Time) Field is optional
(required=False).