### PR TITLE
Added support for schemaless/empty {'type': 'object'} fields.

### DIFF
--- a/jsonmodels/builders.py
+++ b/jsonmodels/builders.py
@@ -142,6 +142,8 @@ class PrimitiveBuilder(Builder):
             return {'type': 'number'}
         elif issubclass(self.type, float):
             return {'type': 'number'}
+        elif self.type == dict:
+            return {'type': 'object'}
 
         raise errors.FieldNotSupported(
             "Can't specify value schema!", self.type

--- a/jsonmodels/fields.py
+++ b/jsonmodels/fields.py
@@ -304,7 +304,14 @@ class EmbeddedField(BaseField):
         return self.types[0]
 
     def to_struct(self, value):
-        return value.to_struct()
+        try:
+            return value.to_struct()
+        except AttributeError:
+            # Only when we specify `dict` as a type should
+            # we return the raw value.
+            if dict not in self.types:
+                raise
+            return value.copy()
 
 
 class _LazyType(object):

--- a/tests/fixtures/schema_empty_object.json
+++ b/tests/fixtures/schema_empty_object.json
@@ -1,0 +1,24 @@
+{
+    "additionalProperties": false,
+    "definitions": {
+        "tests_test_schema_structured": {
+            "additionalProperties": false,
+            "properties": {
+                "key": {"type": "string"},
+                "value": {"type": "string"}
+            },
+            "type": "object"
+        }
+    },
+    "properties": {
+        "arbitrary": {"type": "object"},
+        "structured": "#/definitions/tests_test_schema_structured",
+        "type_choices": {
+            "oneOf": [
+                "#/definitions/tests_test_schema_structured",
+                {"type": "object"}
+            ]
+        }
+    },
+    "type": "object"
+}

--- a/tests/test_jsonmodels.py
+++ b/tests/test_jsonmodels.py
@@ -574,3 +574,21 @@ def test_equality_missing_required_field():
     assert Model(age=1) == Model(age=1)
     assert Model(age=1) != Model(age=2)
     assert Model(name='William', age=1) != Model(age=1)
+
+
+def test_empty_object():
+    class Model(models.Base):
+        data = fields.EmbeddedField(dict)
+
+    inst = Model(data={'wiz': 'boing'})
+
+    assert inst.data == {'wiz': 'boing'}
+
+
+def test_empty_object_to_struct():
+    class Model(models.Base):
+        data = fields.EmbeddedField(dict)
+
+    inst = Model(data={'wiz': 'boing'})
+
+    assert inst.to_struct() == {'data': {'wiz': 'boing'}}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -371,3 +371,19 @@ def test_schema_for_unsupported_primitive():
 
     with pytest.raises(errors.FieldNotSupported):
         Person.to_json_schema()
+
+
+def test_schema_empty_object():
+    class Structured(models.Base):
+        key = fields.StringField()
+        value = fields.StringField()
+
+    class DataContainer(models.Base):
+        arbitrary = fields.EmbeddedField(dict)
+        structured = fields.EmbeddedField(Structured)
+        type_choices = fields.EmbeddedField([Structured, dict])
+
+    schema = DataContainer.to_json_schema()
+
+    pattern = get_fixture('schema_empty_object.json')
+    assert compare_schemas(pattern, schema)


### PR DESCRIPTION
The JSON-Schema spec supports fields that are schemaless or 'empty' fields.

Common use case: (not) validating arbitrary data inside a more defined schema.