### PR TITLE
Add parsing to IntField

### DIFF
--- a/jsonmodels/fields.py
+++ b/jsonmodels/fields.py
@@ -129,6 +129,13 @@ class IntField(BaseField):
 
     types = (int,)
 
+    def parse_value(self, value):
+        """Cast value to `int`, e.g. from string or long"""
+        parsed = super(IntField, self).parse_value(value)
+        if parsed is None:
+            return parsed
+        return int(parsed)
+
 
 class FloatField(BaseField):
 

--- a/tests/test_data_initialization.py
+++ b/tests/test_data_initialization.py
@@ -1,4 +1,5 @@
 import pytest
+import six
 
 from jsonmodels import models, fields, errors
 
@@ -296,3 +297,22 @@ def test_deep_initialization_for_embed_field():
         car = parking.car
         assert isinstance(car, Car)
         assert car.brand == 'awesome brand'
+
+
+def test_int_field_parsing():
+
+    class Counter(models.Base):
+        value = fields.IntField()
+
+    counter0 = Counter(value=None)
+    assert counter0.value is None
+    counter1 = Counter(value=1)
+    assert isinstance(counter1.value, int)
+    assert counter1.value == 1
+    counter2 = Counter(value='2')
+    assert isinstance(counter2.value, int)
+    assert counter2.value == 2
+    if not six.PY3:
+        counter3 = Counter(value=long(3))  # noqa
+        assert isinstance(counter3.value, int)
+        assert counter3.value == 3

--- a/tests/test_jsonmodels.py
+++ b/tests/test_jsonmodels.py
@@ -43,9 +43,6 @@ def test_type_validation():
 
     alan = Person()
 
-    with pytest.raises(errors.ValidationError):
-        alan.age = '42'
-
     alan.age = 42
 
 
@@ -195,11 +192,6 @@ def test_embedded_model():
     assert entity.secondary is None
     entity.name = 'chuck'
     entity.secondary = Secondary()
-    entity.secondary.data = 42
-
-    with pytest.raises(errors.ValidationError):
-        entity.secondary.data = '42'
-
     entity.secondary.data = 42
 
     with pytest.raises(errors.ValidationError):

--- a/tests/test_lazy_loading.py
+++ b/tests/test_lazy_loading.py
@@ -65,11 +65,6 @@ def test_embedded_model(model):
     entity.secondary.data = 42
 
     with pytest.raises(errors.ValidationError):
-        entity.secondary.data = '42'
-
-    entity.secondary.data = 42
-
-    with pytest.raises(errors.ValidationError):
         entity.secondary = 'something different'
 
     entity.secondary = None


### PR DESCRIPTION
Having IntField parse its input allows a field of this type to be
assigned by a textual representation of a string or (in python 2) a
long.

This allows data sources which mix ints and longs, or ints and their
representation, to provide legal values to JSON models.