### PR TITLE
Remove pyhistory from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ mock
 pep8
 py
 pyflakes
-pyhistory
 pytest
 pytest-cov
 sphinxcontrib-spelling


### PR DESCRIPTION
It appears pyhistory isn't used. Additionally, it doesn't have an RPM
package. If we want to make jsonmodels an RPM package, this requirement
has to be removed (or made an RPM as well).