### PR TITLE
Fixing typo in the Length validator

### DIFF
--- a/jsonmodels/validators.py
+++ b/jsonmodels/validators.py
@@ -164,7 +164,7 @@ class Length(object):
                 val=value, min=self.minimum_value
             ))
 
-        if self.minimum_value is not None and len_ > self.maximum_value:
+        if self.maximum_value is not None and len_ > self.maximum_value:
             raise ValidationError(
                 "Value '{val}' length is bigger than "
                 "allowed maximum '{max}'.".format(


### PR DESCRIPTION
This bug hasn't been reported but it seems an easy typo. Tests should be catching this issue too.