### PR TITLE
Refactor some code for understandability

### DIFF
--- a/jsonmodels/collections.py
+++ b/jsonmodels/collections.py
@@ -1,5 +1,3 @@
-
-
 class ModelCollection(list):
 
     """`ModelCollection` is list which validates stored values.

--- a/jsonmodels/fields.py
+++ b/jsonmodels/fields.py
@@ -14,6 +14,9 @@ from .collections import ModelCollection
 NotSet = object()
 
 
+_FIELD_NAME_REGEX = re.compile(r'^[A-Za-z_](([\w\-]*)?\w+)?$')
+
+
 class BaseField(object):
 
     """Base class for all fields."""
@@ -132,15 +135,14 @@ class BaseField(object):
         return self._default if self.has_default else None
 
     def _validate_name(self):
-        if self.name is not None and not re.match('^[A-Za-z_](([\w\-]*)?\w+)?$', self.name):
+        if self.name is not None \
+                and not re.match(_FIELD_NAME_REGEX, self.name):
             raise ValueError('Wrong name', self.name)
 
     def structure_name(self, default):
         return self.name if self.name is not None else default
 
-
-    def structue_name(self, default):
-        return self.structure_name(default)
+    structue_name = structure_name
 
 
 class StringField(BaseField):

--- a/jsonmodels/fields.py
+++ b/jsonmodels/fields.py
@@ -71,13 +71,13 @@ class BaseField(object):
         if instance is None:
             return self
         else:
-            self._check_value(instance)
+            self._maybe_assign_default_value(instance)
             return self.memory[instance._cache_key]
 
     def _finish_initialization(self, owner):
         pass
 
-    def _check_value(self, obj):
+    def _maybe_assign_default_value(self, obj):
         if obj._cache_key not in self.memory:
             self.__set__(obj, self.get_default_value())
 

--- a/jsonmodels/fields.py
+++ b/jsonmodels/fields.py
@@ -99,7 +99,8 @@ class BaseField(object):
         if value is not None and not isinstance(value, self.types):
             raise ValidationError(
                 'Value {value!r} is wrong, expected type {types!r}'
-                .format(value=value, types=', '.join(t.__name__ for t in self.types))
+                .format(value=value,
+                        types=', '.join(t.__name__ for t in self.types))
             )
 
     def _check_types(self):

--- a/jsonmodels/fields.py
+++ b/jsonmodels/fields.py
@@ -137,8 +137,12 @@ class BaseField(object):
         if not re.match('^[A-Za-z_](([\w\-]*)?\w+)?$', self.name):
             raise ValueError('Wrong name', self.name)
 
-    def structue_name(self, default):
+    def structure_name(self, default):
         return self.name if self.name is not None else default
+
+
+    def structue_name(self, default):
+        return self.structure_name(default)
 
 
 class StringField(BaseField):

--- a/jsonmodels/fields.py
+++ b/jsonmodels/fields.py
@@ -132,9 +132,7 @@ class BaseField(object):
         return self._default if self.has_default else None
 
     def _validate_name(self):
-        if self.name is None:
-            return
-        if not re.match('^[A-Za-z_](([\w\-]*)?\w+)?$', self.name):
+        if self.name is not None and not re.match('^[A-Za-z_](([\w\-]*)?\w+)?$', self.name):
             raise ValueError('Wrong name', self.name)
 
     def structure_name(self, default):
@@ -163,7 +161,8 @@ class IntField(BaseField):
         parsed = super(IntField, self).parse_value(value)
         if parsed is None:
             return parsed
-        return int(parsed)
+        else:
+            return int(parsed)
 
 
 class FloatField(BaseField):
@@ -248,15 +247,12 @@ class ListField(BaseField):
 
     def parse_value(self, values):
         """Cast value to proper collection."""
-        result = self.get_default_value()
-
         if not values:
-            return result
-
-        if not isinstance(values, list):
+            return self.get_default_value()
+        elif not isinstance(values, list):
             return values
-
-        return [self._cast_value(value) for value in values]
+        else:
+            return [self._cast_value(value) for value in values]
 
     def _cast_value(self, value):
         if isinstance(value, self.items_types):
@@ -334,9 +330,9 @@ class EmbeddedField(BaseField):
         """Parse value to proper model type."""
         if not isinstance(value, dict):
             return value
-
-        embed_type = self._get_embed_type()
-        return embed_type(**value)
+        else:
+            embed_type = self._get_embed_type()
+            return embed_type(**value)
 
     def _get_embed_type(self):
         if len(self.types) != 1:
@@ -423,9 +419,10 @@ class TimeField(StringField):
         """Parse string into instance of `time`."""
         if value is None:
             return value
-        if isinstance(value, datetime.time):
+        elif isinstance(value, datetime.time):
             return value
-        return parse(value).timetz()
+        else:
+            return parse(value).timetz()
 
 
 class DateField(StringField):
@@ -455,9 +452,10 @@ class DateField(StringField):
         """Parse string into instance of `date`."""
         if value is None:
             return value
-        if isinstance(value, datetime.date):
+        elif isinstance(value, datetime.date):
             return value
-        return parse(value).date()
+        else:
+            return parse(value).date()
 
 
 class DateTimeField(StringField):
@@ -486,7 +484,7 @@ class DateTimeField(StringField):
         """Parse string into instance of `datetime`."""
         if isinstance(value, datetime.datetime):
             return value
-        if value:
+        elif value:
             return parse(value)
         else:
             return None

--- a/jsonmodels/fields.py
+++ b/jsonmodels/fields.py
@@ -98,10 +98,8 @@ class BaseField(object):
     def _validate_against_types(self, value):
         if value is not None and not isinstance(value, self.types):
             raise ValidationError(
-                'Value is wrong, expected type "{types}"'.format(
-                    types=', '.join([t.__name__ for t in self.types])
-                ),
-                value,
+                'Value {value!r} is wrong, expected type {types!r}'
+                .format(value=value, types=', '.join(t.__name__ for t in self.types))
             )
 
     def _check_types(self):

--- a/jsonmodels/fields.py
+++ b/jsonmodels/fields.py
@@ -3,7 +3,7 @@ import re
 from weakref import WeakKeyDictionary
 
 import six
-from dateutil.parser import parse
+import dateutil.parser
 
 from .errors import ValidationError
 from .collections import ModelCollection
@@ -431,7 +431,7 @@ class TimeField(StringField):
         elif isinstance(value, datetime.time):
             return value
         else:
-            return parse(value).timetz()
+            return dateutil.parser.parse(value).timetz()
 
 
 class DateField(StringField):
@@ -464,7 +464,7 @@ class DateField(StringField):
         elif isinstance(value, datetime.date):
             return value
         else:
-            return parse(value).date()
+            return dateutil.parser.parse(value).date()
 
 
 class DateTimeField(StringField):
@@ -494,6 +494,6 @@ class DateTimeField(StringField):
         if isinstance(value, datetime.datetime):
             return value
         elif value:
-            return parse(value)
+            return dateutil.parser.parse(value)
         else:
             return None

--- a/jsonmodels/fields.py
+++ b/jsonmodels/fields.py
@@ -212,7 +212,7 @@ class ListField(BaseField):
             try:
                 self.items_types = tuple(items_types)
             except TypeError:
-                self.items_types = items_types,
+                self.items_types = (items_types, )
         else:
             self.items_types = tuple()
 
@@ -271,11 +271,11 @@ class ListField(BaseField):
         super(ListField, self)._finish_initialization(owner)
 
         types = []
-        for type in self.items_types:
-            if isinstance(type, _LazyType):
-                types.append(type.evaluate(owner))
+        for type_ in self.items_types:
+            if isinstance(type_, _LazyType):
+                types.append(type_.evaluate(owner))
             else:
-                types.append(type)
+                types.append(type_)
         self.items_types = tuple(types)
 
     def _elem_to_struct(self, value):

--- a/jsonmodels/models.py
+++ b/jsonmodels/models.py
@@ -44,13 +44,14 @@ class Base(six.with_metaclass(JsonmodelMeta, object)):
             if name in values:
                 field.__set__(self, values.pop(name))
 
-    def get_field(self, field_name):
+    @classmethod
+    def get_field(cls, field_name):
         """Get field associated with given attribute."""
-        for attr_name, field in self:
-            if field_name == attr_name:
-                return field
-
-        raise errors.FieldNotFound('Field not found', field_name)
+        field = getattr(cls, field_name, None)
+        if isinstance(field, BaseField):
+            return field
+        else:
+            raise errors.FieldNotFound('Field not found', field_name)
 
     def __iter__(self):
         """Iterate through fields and values."""

--- a/jsonmodels/models.py
+++ b/jsonmodels/models.py
@@ -58,22 +58,22 @@ class Base(six.with_metaclass(JsonmodelMeta, object)):
 
     def validate(self):
         """Explicitly validate all the fields."""
-        for name, field in self:
+        for attr_name, field in self:
             try:
                 field.validate_for_object(self)
             except ValidationError as error:
                 raise ValidationError(
-                    "Error for field '{name}'.".format(name=name),
-                    error,
+                    'Error for field {attr_name!r}: {error}'
+                    .format(attr_name=attr_name, error=error)
                 )
 
     @classmethod
     def iterate_over_fields(cls):
         """Iterate through fields as `(attribute_name, field_instance)`."""
-        for clsname in dir(cls):
-            clsattr = getattr(cls, clsname)
-            if isinstance(clsattr, BaseField):
-                yield clsname, clsattr
+        for attr_name in dir(cls):
+            field = getattr(cls, attr_name)
+            if isinstance(field, BaseField):
+                yield attr_name, field
 
     @classmethod
     def iterate_with_name(cls):
@@ -98,11 +98,11 @@ class Base(six.with_metaclass(JsonmodelMeta, object)):
 
     def __repr__(self):
         attrs = {}
-        for name, field in self:
+        for attr_name, field in self:
             try:
-                attr = getattr(self, name)
+                attr = getattr(self, attr_name)
                 if attr is not None:
-                    attrs[name] = repr(attr)
+                    attrs[attr_name] = repr(attr)
             except ValidationError:
                 pass
 
@@ -129,14 +129,14 @@ class Base(six.with_metaclass(JsonmodelMeta, object)):
         if type(other) is not type(self):
             return False
 
-        for name, _ in self.iterate_over_fields():
+        for attr_name, _ in self.iterate_over_fields():
             try:
-                our = getattr(self, name)
+                our = getattr(self, attr_name)
             except errors.ValidationError:
                 our = None
 
             try:
-                their = getattr(other, name)
+                their = getattr(other, attr_name)
             except errors.ValidationError:
                 their = None
 

--- a/jsonmodels/models.py
+++ b/jsonmodels/models.py
@@ -55,8 +55,7 @@ class Base(six.with_metaclass(JsonmodelMeta, object)):
 
     def __iter__(self):
         """Iterate through fields and values."""
-        for name, field in self.iterate_over_fields():
-            yield name, field
+        yield from self.iterate_over_fields()
 
     def validate(self):
         """Explicitly validate all the fields."""
@@ -72,21 +71,21 @@ class Base(six.with_metaclass(JsonmodelMeta, object)):
     @classmethod
     def iterate_over_fields(cls):
         """Iterate through fields as `(attribute_name, field_instance)`."""
-        for attr in dir(cls):
-            clsattr = getattr(cls, attr)
+        for clsname in dir(cls):
+            clsattr = getattr(cls, clsname)
             if isinstance(clsattr, BaseField):
-                yield attr, clsattr
+                yield clsname, clsattr
 
     @classmethod
     def iterate_with_name(cls):
         """Iterate over fields, but also give `structure_name`.
 
-        Format is `(attribute_name, structue_name, field_instance)`.
+        Format is `(attribute_name, structure_name, field_instance)`.
         Structure name is name under which value is seen in structure and
         schema (in primitives) and only there.
         """
         for attr_name, field in cls.iterate_over_fields():
-            structure_name = field.structue_name(attr_name)
+            structure_name = field.structure_name(attr_name)
             yield attr_name, structure_name, field
 
     def to_struct(self):

--- a/jsonmodels/models.py
+++ b/jsonmodels/models.py
@@ -36,13 +36,12 @@ class Base(six.with_metaclass(JsonmodelMeta, object)):
     def populate(self, **values):
         """Populate values to fields. Skip non-existing."""
         values = values.copy()
-        fields = list(self.iterate_with_name())
-        for _, structure_name, field in fields:
+        for attr_name, structure_name, field in self.iterate_with_name():
+            # set field by structure name
             if structure_name in values:
                 field.__set__(self, values.pop(structure_name))
-        for name, _, field in fields:
-            if name in values:
-                field.__set__(self, values.pop(name))
+            elif attr_name in values:
+                field.__set__(self, values.pop(attr_name))
 
     @classmethod
     def get_field(cls, field_name):

--- a/jsonmodels/models.py
+++ b/jsonmodels/models.py
@@ -19,10 +19,10 @@ class JsonmodelMeta(type):
         }
         taken_names = set()
         for name, field in fields.items():
-            structue_name = field.structue_name(name)
-            if structue_name in taken_names:
-                raise ValueError('Name taken', structue_name, name)
-            taken_names.add(structue_name)
+            structure_name = field.structure_name(name)
+            if structure_name in taken_names:
+                raise ValueError('Name taken', structure_name, name)
+            taken_names.add(structure_name)
 
 
 class Base(six.with_metaclass(JsonmodelMeta, object)):
@@ -99,7 +99,7 @@ class Base(six.with_metaclass(JsonmodelMeta, object)):
 
     def __repr__(self):
         attrs = {}
-        for name, _ in self:
+        for name, field in self:
             try:
                 attr = getattr(self, name)
                 if attr is not None:
@@ -152,3 +152,4 @@ class Base(six.with_metaclass(JsonmodelMeta, object)):
 
 class _CacheKey(object):
     """Object to identify model in memory."""
+    pass

--- a/jsonmodels/models.py
+++ b/jsonmodels/models.py
@@ -31,7 +31,12 @@ class Base(six.with_metaclass(JsonmodelMeta, object)):
 
     def __init__(self, **kwargs):
         self._cache_key = _CacheKey()
+        self.initialize_fields()
         self.populate(**kwargs)
+
+    def initialize_fields(self):
+        for _, _, _ in self.iterate_with_name():
+            pass
 
     def populate(self, **values):
         """Populate values to fields. Skip non-existing."""


### PR DESCRIPTION
Hello,
I spent a fair amount of time reading through the code of jsonmodels to understand how it worked. It employs a fair amount of interesting python constructs, like `__get__` and `__set__` methods of `BaseField` and a healthy use of metaclasses and class methods.

To help myself understand what was going on, I found myself making small changes to the code for readability and interpretability. This includes
- consistently use `if/else` to make control flow explicit
- fix typo of `structure_name` (still leaving `structue_name` for backwards compatibility)
- use more explicit names for iteration over class attributes
```
# original
for attr in dir(cls):
    clsattr = getattr(cls, attr)

# new
for attr_name in dir(cls):
    field = getattr(cls, attr_name)
```
- try to simplify logic of field initialization by adding an `_initialized` attribute to `BaseField` and guarding against re-initialization
- make `Base.get_field` a classmethod, which avoids a linear search through the entire set of fields on each access

Hope this is helpful, let me know what you think!